### PR TITLE
18 print with encoding

### DIFF
--- a/gl2f/cat.py
+++ b/gl2f/cat.py
@@ -9,10 +9,10 @@ def cat(i, args):
 	if args.dl:
 		save(i, args)
 	fm = pretty.Formatter()
-	fm.print(i)
+	fm.print(i, encoding=args.encoding)
 	for s in article.lines(i, args.style, args.sixel):
-		print(s, end='')
-	print()
+		term.write_with_encoding(s, encoding=args.encoding, errors='ignore')
+	term.write_with_encoding('\n', encoding=args.encoding)
 
 
 def subcommand(args):
@@ -39,6 +39,8 @@ def add_args(parser):
 	lister.add_args(parser)
 	pretty.add_args(parser)
 	parser.set_defaults(format='author:title')
+
+	parser.add_argument('--encoding')
 
 	parser.add_argument('--style', type=str, choices={'full', 'compact', 'compressed', 'plain'}, default='compact')
 	parser.add_argument('--no-image', dest='sixel', action='store_false',

--- a/gl2f/core/pretty.py
+++ b/gl2f/core/pretty.py
@@ -98,8 +98,8 @@ class Formatter:
 			self.sep.join(zen.ljust(self.functions[k](item), self.width.get(k, 0)) for k in self.keys())
 		)
 
-	def print(self, item, end='\n'):
-		print(self.format(item), end=end)
+	def print(self, item, end='\n', encoding=None):
+		term.write_with_encoding(f'{self.format(item)}\n', encoding=encoding)
 
 
 def add_args(parser):

--- a/gl2f/local.py
+++ b/gl2f/local.py
@@ -14,7 +14,7 @@ def ls(args):
 
 	fm = pretty.from_args(args, items)
 	for i in items:
-		fm.print(i)
+		fm.print(i, encoding=args.encoding)
 
 
 def clear_cache():
@@ -178,6 +178,7 @@ def add_args(parser):
 	p.add_argument('--order', type=str,
 		help='sort order')
 	pretty.add_args(p)
+	p.add_argument('--encoding')
 	p.set_defaults(handler=ls, format='author:title')
 
 	sub.add_parser('stat').set_defaults(handler=lambda _:stat())

--- a/gl2f/ls.py
+++ b/gl2f/ls.py
@@ -8,9 +8,10 @@ def subcommand(args):
 	fm = pretty.from_args(args, items)
 
 	for i in items:
-		fm.print(i)
+		fm.print(i, encoding=args.encoding)
 
 def add_args(parser):
 	lister.add_args(parser)
 	pretty.add_args(parser)
 	parser.set_defaults(handler=subcommand)
+	parser.add_argument('--encoding')

--- a/gl2f/search.py
+++ b/gl2f/search.py
@@ -38,10 +38,10 @@ def subcommand(args):
 	for c, t, i in sorted(zip(counts, texts, items), reverse=True, key=lambda x:x[0]):
 		if c == 0: break
 
-		print(hi.sub(
+		term.write_with_encoding(hi.sub(
 			term.mod(r'\g<match>', term.color('yellow'), term.inv()),
 			fm.format(i)
-		))
+		) + '\n', args.encoding)
 
 		ranges = [(i.start()-20, i.end()+20) for i in hi.finditer(t)]
 		merged = merge(ranges)
@@ -49,12 +49,12 @@ def subcommand(args):
 			merged = merged[:5]
 
 		for begin, end in merged:
-			print('> ' + hi.sub(
+			term.write_with_encoding('> ' + hi.sub(
 				term.mod(r'\g<match>', term.color('yellow')),
 				t[max(0, begin):min(len(t), end)] + term.reset()
-			))
+			) + '\n', args.encoding)
 
-		print()
+		term.write_with_encoding('\n', args.encoding)
 
 
 def add_args(parser):
@@ -64,5 +64,6 @@ def add_args(parser):
 	parser.set_defaults(date='%m/%d', number=30)
 
 	parser.add_argument('keywords', nargs='+')
+	parser.add_argument('--encoding')
 
 	parser.set_defaults(handler=subcommand)

--- a/print.py
+++ b/print.py
@@ -1,0 +1,25 @@
+import sys
+from sys import stdout
+
+
+c = sys.argv[sys.argv.index('--encoding')+1] if '--encoding' in sys.argv else sys.stdout.encoding
+
+print(sys.stdout.encoding, flush=True)
+
+def print_with_encoding(*ss, end='\n', sep=' ', errors='replace'):
+	stdout.buffer.write((sep.join(ss)+end).encode(c, errors=errors))
+
+s = '''
+原田都愛 🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆🦆 https://girls2-fc.jp/page/blogs/305718498280080541
+原田都愛 🥳🥳🥳🥳🥳                     https://girls2-fc.jp/page/blogs/296237525440136273
+原田都愛 🥲😄                           https://girls2-fc.jp/page/blogs/571710357186282433
+原田都愛 🥲                             https://girls2-fc.jp/page/blogs/567537622214247465
+原田都愛 🥦                             https://girls2-fc.jp/page/blogs/505608708496032705
+原田都愛 🤪🤪🤪🤪🤪🤪🤪                 https://girls2-fc.jp/page/blogs/526227849607119675
+原田都愛 🤔🤔🤔🤔🤔🤔                   https://girls2-fc.jp/page/blogs/304428618660971677
+原田都愛 🟦                             https://girls2-fc.jp/page/blogs/590320261769724865
+原田都愛 🟦                             https://girls2-fc.jp/page/blogs/531432161908097851
+原田都愛 🟥                             https://girls2-fc.jp/page/blogs/661038676481934273
+'''
+
+print_with_encoding(s, s)


### PR DESCRIPTION
- update ayame not to modify texts without terminal
- add encoding tester
- print with encoding in ls, local, and search
- print with encoding in cat


handle encoding errors to resolve erroprs on pipe or redirect, while enable to manually set encoding.
still has probelem in windows clipboard