### PR TITLE
change scroll default

### DIFF
--- a/gl2f/cat.py
+++ b/gl2f/cat.py
@@ -39,7 +39,7 @@ def add_args(parser):
 	lister.add_args(parser)
 	pretty.add_args(parser)
 	parser.set_defaults(format='author:title')
-	util.add_paging_args(parser)
+	util.add_paging_args(parser, 'never')
 
 	parser.add_argument('--encoding')
 	parser.add_argument('--style', type=str, choices={'full', 'compact', 'compressed', 'plain'}, default='compact')

--- a/gl2f/core/util.py
+++ b/gl2f/core/util.py
@@ -20,8 +20,11 @@ def rule(length=None):
 	hand = '-' * ((length-5)//2)
 	return f'{hand}・_・{hand}'
 
-paging_choices = ['auto', 'never']
-def add_paging_args(parser):
-	parser.add_argument('--paging', type=str, choices=paging_choices, default='auto',
-		help=f'specify when to use the pager, or use -P to disable (*{", ".join(paging_choices)})')
-	parser.add_argument('-P', dest='paging', action='store_const', const='never')
+paging_choices = ['always', 'never']
+def add_paging_args(parser, default):
+	parser.add_argument('--scroll', type=str, nargs='?',
+		choices = paging_choices,
+		default = default,
+		const = 'always',
+		help = f'specify when to use the pager, or use -P to disable (*{", ".join(paging_choices)})')
+	parser.add_argument('-S', dest='scroll', action='store_const', const='never')

--- a/gl2f/local.py
+++ b/gl2f/local.py
@@ -15,7 +15,12 @@ def ls(args):
 		args.format = 'page:' + args.format
 
 	fm = pretty.from_args(args, items)
-	if args.paging != 'never':
+
+	if args.scroll == 'auto':
+		_, h = os.get_terminal_size()
+		args.scroll = 'never' if len(items) < h-1 else 'always'
+
+	if args.scroll == 'always':
 		term.scroll(map(fm.format, items), lambda:'')
 	else:
 		for i in items:
@@ -410,7 +415,7 @@ def add_args(parser):
 	p.add_argument('--order', type=str,
 		help='sort order')
 	pretty.add_args(p)
-	util.add_paging_args(p)
+	util.add_paging_args(p, 'auto')
 	p.add_argument('--encoding')
 	p.set_defaults(handler=ls, format='author:title')
 

--- a/gl2f/ls.py
+++ b/gl2f/ls.py
@@ -5,7 +5,8 @@ def subcommand(args):
 	items, _ = lister.list_contents(args)
 
 	fm = pretty.from_args(args, items)
-	if args.paging == 'never':
+
+	if args.scroll == 'never':
 		for i in items:
 			fm.print(i, encoding=args.encoding)
 	else:
@@ -20,7 +21,7 @@ def add_args(parser):
 
 	lister.add_args(parser)
 	pretty.add_args(parser)
-	util.add_paging_args(parser)
+	util.add_paging_args(parser, 'never')
 	parser.set_defaults(handler=subcommand)
 	parser.add_argument('--encoding')
 

--- a/gl2f/search.py
+++ b/gl2f/search.py
@@ -62,7 +62,12 @@ def subcommand(args):
 				yield ''
 			args.page += 1
 
-	term.scroll(gen(), eof=util.rule)
+	if args.scroll == 'always':
+		term.scroll(gen(), eof=util.rule)
+	else:
+		for i in gen():
+			term.write_with_encoding(i, encoding=args.encoding)
+			print()
 
 
 def add_to():
@@ -79,6 +84,8 @@ def add_args(parser):
 	parser.add_argument('keywords', nargs='+')
 	parser.add_argument('--encoding')
 	parser.add_argument('--sort', action='store_true')
+
+	util.add_paging_args(parser, 'always')
 
 	parser.set_defaults(handler=subcommand)
 


### PR DESCRIPTION
- **update README.md**
- **do not use terminal.select**
- **page in selector**
- **get search command structured**
- **scroll for search**
- **article.lines returns lines**
- **pager on cat**
- **scroll on ls**
- **clean**
- **add completion for local.ls**
- **remove index from formatter**
- **fix pretty**
- **share paging argument setting**
- **remove dl option from cat**
- **change pager option name and defaults**
