### PR TITLE
fix terminal errors

### DIFF
--- a/gl2f/cat.py
+++ b/gl2f/cat.py
@@ -26,7 +26,7 @@ def subcommand(args):
 
 	if never_page:
 		for line in g:
-			print(line)
+			term.write_with_encoding(line, encoding=args.encoding)
 	else:
 		term.scroll(g, eof=util.rule)
 

--- a/gl2f/core/util.py
+++ b/gl2f/core/util.py
@@ -27,4 +27,4 @@ def add_paging_args(parser, default):
 		default = default,
 		const = 'always',
 		help = f'specify when to use the pager, or use -P to disable (*{", ".join(paging_choices)})')
-	parser.add_argument('-S', dest='scroll', action='store_const', const='never')
+	parser.add_argument('-P', dest='scroll', action='store_const', const='never')

--- a/gl2f/local.py
+++ b/gl2f/local.py
@@ -1,5 +1,6 @@
 import re
 import os, json
+from sys import stdout
 from .core import pretty, local, util
 from .core.config import data as config
 from .core.local import site, archive
@@ -16,6 +17,9 @@ def ls(args):
 		args.format = 'page:' + args.format
 
 	fm = pretty.from_args(args, items)
+
+	if not stdout.isatty():
+		args.scroll = 'never'
 
 	if args.scroll == 'auto':
 		_, h = os.get_terminal_size()


### PR DESCRIPTION
- **update README.md**
- **do not use terminal.select**
- **page in selector**
- **get search command structured**
- **scroll for search**
- **article.lines returns lines**
- **pager on cat**
- **scroll on ls**
- **clean**
- **add completion for local.ls**
- **remove index from formatter**
- **fix pretty**
- **share paging argument setting**
- **remove dl option from cat**
- **change pager option name and defaults**
- **fix args**
- **update ayame**
- **fix terminal errors**
