### PR TITLE
sort local content (v0.4)

### DIFF
--- a/gl2f/core/local/content.py
+++ b/gl2f/core/local/content.py
@@ -7,7 +7,7 @@ def load(i):
 
 def get_ids():
 	root = fs.refdir_untouch('contents')
-	return [i for i in fs.listdir('contents') if os.path.isdir(os.path.join(root, i))]
+	return sorted((i for i in fs.listdir('contents') if os.path.isdir(os.path.join(root, i))), key=int)
 
 def stat():
 	return {os.path.basename(p): {

--- a/gl2f/local.py
+++ b/gl2f/local.py
@@ -6,8 +6,7 @@ from .core.local import site, archive
 
 def ls(args):
 	from .ayame import terminal as term
-	items = [local.content.load(i) for i in sorted(local.content.get_ids())]
-
+	items = [local.content.load(i) for i in local.content.get_ids()]
 	if args.order:
 		a = args.order.split(':')
 		items.sort(key=lambda i: i[a[0]], reverse=(len(a)==2 and a[1]=='desc'))


### PR DESCRIPTION
- **update README.md**
- **do not use terminal.select**
- **page in selector**
- **get search command structured**
- **scroll for search**
- **article.lines returns lines**
- **pager on cat**
- **scroll on ls**
- **clean**
- **add completion for local.ls**
- **remove index from formatter**
- **fix pretty**
- **share paging argument setting**
- **remove dl option from cat**
- **change pager option name and defaults**
- **fix args**
- **update ayame**
- **sort local content ids**
